### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -16,7 +16,7 @@ icon-path = "linkedin.png"
 language = "Rust"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release && cp ./target/wasm32-wasip2/release/linkedin_capi_component.wasm linkedin_capi.wasm"
+command = "cargo build --target wasm32-wasip2 --release && rm -f linkedin_capi.wasm && cp ./target/wasm32-wasip2/release/linkedin_capi_component.wasm linkedin_capi.wasm"
 output_path = "linkedin_capi.wasm"
 
 [component.settings.linkedin_access_token]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink